### PR TITLE
feat: Web，模态框完成，且实现 week-selector 周数选择器

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "autoprefixer": "^10.4.20",
         "bootstrap": "^4.6.0",
         "jquery": "^3.5.1",
-        "ng-zorro-antd": "^15.1.0",
+        "ng-zorro-antd": "^15.1.1",
         "popper.js": "^1.16.1",
         "rxjs": "~7.8.0",
         "sweetalert2": "^11.14.1",
@@ -8225,6 +8225,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmmirror.com/ng-zorro-antd/-/ng-zorro-antd-15.1.1.tgz",
       "integrity": "sha512-u69Lt3qCA9nYJFzAJitVZ21XGP9uuBA5acvtbC24cTjHMKFs699t2UTp1umUNwb7Ix54vPfKyjovZpnqcebC6g==",
+      "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^15.0.0",
         "@ant-design/icons-angular": "^15.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
     "autoprefixer": "^10.4.20",
     "bootstrap": "^4.6.0",
     "jquery": "^3.5.1",
-    "ng-zorro-antd": "^15.1.0",
+    "ng-zorro-antd": "^15.1.1",
     "popper.js": "^1.16.1",
     "rxjs": "~7.8.0",
     "sweetalert2": "^11.14.1",

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -24,38 +24,40 @@ import {CourseModule} from "./course/course.module";
 import {MeModule} from "./me/me.module";
 import { AdminDashboardComponent } from './dashboard/admin-dashboard/admin-dashboard.component';
 import {MyScheduleModule} from "./my-schedule/my-schedule.module";
+import {WeekSelectorModule} from "./core/week-selector/week-selector.module";
 
 registerLocaleData(zh);
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    DashboardComponent,
-    LayoutComponent,
-    LoginComponent,
-    AdminDashboardComponent
-  ],
-  imports: [
-    BrowserModule,
-    AppRoutingModule,
-    HeaderModule,
-    NavModule,
-    AdminModule,
-    HttpClientModule,
-    AuthTokenInterceptorModule,
-    // ApiMockModule,
-    FormsModule,
-    BrowserAnimationsModule,
-    SchoolSelectModule,
-    CourseTableModule,
-    ReactiveFormsModule,
-    CourseModule,
-    MeModule,
-    MyScheduleModule
-  ],
-  providers: [
-    { provide: NZ_I18N, useValue: zh_CN }
-  ],
-  bootstrap: [AppComponent]
+    declarations: [
+        AppComponent,
+        DashboardComponent,
+        LayoutComponent,
+        LoginComponent,
+        AdminDashboardComponent
+    ],
+    imports: [
+        BrowserModule,
+        AppRoutingModule,
+        HeaderModule,
+        NavModule,
+        AdminModule,
+        HttpClientModule,
+        AuthTokenInterceptorModule,
+        // ApiMockModule,
+        FormsModule,
+        BrowserAnimationsModule,
+        SchoolSelectModule,
+        CourseTableModule,
+        ReactiveFormsModule,
+        CourseModule,
+        MeModule,
+        MyScheduleModule,
+        WeekSelectorModule
+    ],
+    providers: [
+        {provide: NZ_I18N, useValue: zh_CN}
+    ],
+    bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/web/src/app/core/week-selector/week-selector.component.css
+++ b/web/src/app/core/week-selector/week-selector.component.css
@@ -1,0 +1,51 @@
+/* 样式：每行 5 个按钮 */
+.week-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.week-buttons button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.week-buttons button:hover {
+  background-color: #e0e0e0;
+}
+
+/* 选中的按钮样式 */
+.week-buttons button.selected {
+  background-color: #4caf50;
+  color: white;
+}
+
+/* 未选中的按钮暗色 */
+.week-buttons button.deselected {
+  background-color: #aaa;
+  color: #fff;
+}
+
+/* 确认按钮样式 */
+.confirm-button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.confirm-button:hover {
+  background-color: #0056b3;
+}

--- a/web/src/app/core/week-selector/week-selector.component.html
+++ b/web/src/app/core/week-selector/week-selector.component.html
@@ -1,0 +1,19 @@
+<div>
+  <label>
+    <input type="radio" [(ngModel)]="weekType" value="all" (change)="selectAllWeeks()"> 全周
+  </label>
+  <label>
+    <input type="radio" [(ngModel)]="weekType" value="odd" (change)="selectAllWeeks()"> 单周
+  </label>
+  <label>
+    <input type="radio" [(ngModel)]="weekType" value="even" (change)="selectAllWeeks()"> 双周
+  </label>
+  <div class="week-buttons">
+    <button *ngFor="let week of allWeekList; let i = index"
+            [class.selected]="selectedWeeks.includes(week)"
+            [class.deselected]="!selectedWeeks.includes(week)"
+            (click)="toggleWeek(week)">
+      {{ i + 1 }}
+    </button>
+  </div>
+</div>

--- a/web/src/app/core/week-selector/week-selector.component.spec.ts
+++ b/web/src/app/core/week-selector/week-selector.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WeekSelectorComponent } from './week-selector.component';
+import {FormsModule} from "@angular/forms";
+
+describe('WeekSelectorComponent', () => {
+  let component: WeekSelectorComponent;
+  let fixture: ComponentFixture<WeekSelectorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WeekSelectorComponent ],
+      imports: [ FormsModule ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(WeekSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/core/week-selector/week-selector.component.ts
+++ b/web/src/app/core/week-selector/week-selector.component.ts
@@ -1,0 +1,94 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR} from '@angular/forms';
+
+@Component({
+  selector: 'app-week-selector',
+  templateUrl: './week-selector.component.html',
+  styleUrls: ['./week-selector.component.css'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: WeekSelectorComponent,
+      multi: true
+    }
+  ]
+})
+export class WeekSelectorComponent implements ControlValueAccessor, OnInit {
+  @Input() allWeeks: number = 0; // 接收父组件传递的总周数
+  @Input() formControl: FormControl = new FormControl();
+  @Output() weekSelectionChange = new EventEmitter<{ weeks: number[], weekType: 'any' | 'all' | 'odd' | 'even' }>(); // 向父组件传递选择结果
+
+  selectedWeeks: number[] = []; // 存储已选择的周数
+  weekType: 'any' | 'all' | 'odd' | 'even'= 'all'; // 周数类型，默认全选
+  allWeekList: number[] = [];
+
+  ngOnInit(): void {
+    if (this.allWeeks !== 0) {
+      this.allWeekList = Array.from({length: this.allWeeks!}, (_, index) => index + 1);
+    }
+    this.selectAllWeeks();
+  }
+
+  // 根据周类型自动选中
+  selectAllWeeks() {
+    // this.selectedWeeks = [];
+    if (this.weekType === 'all') {
+      this.selectedWeeks = Array.from({length: this.allWeeks}, (_, index) => index + 1);
+    } else if (this.weekType === 'odd') {
+      this.selectedWeeks = Array.from({length: this.allWeeks}, (_, index) => (index + 1) % 2 === 1 ? index + 1 : null).filter(x => x !== null) as number[];
+    } else if (this.weekType === 'even') {
+      this.selectedWeeks = Array.from({length: this.allWeeks}, (_, index) => (index + 1) % 2 === 0 ? index + 1 : null).filter(x => x!== null) as number[];
+    }
+    this.updateWeekType();
+    this.emitWeekSelection();
+  }
+
+  // 选择某一周
+  toggleWeek(week: number) {
+    const index = this.selectedWeeks.indexOf(week);
+    if (index > -1) {
+      // 如果周数已被选中，取消选中
+      this.selectedWeeks.splice(index, 1);
+    } else {
+      // 如果周数未被选中，添加到已选中列表
+      this.selectedWeeks.push(week);
+    }
+    this.updateWeekType();
+    this.emitWeekSelection();
+  }
+
+  // 更新周类型（根据已选中的周数自动调整）
+  updateWeekType() {
+    const oddWeeksSelected = this.selectedWeeks.filter(week => week % 2 === 1).length;
+    const evenWeeksSelected = this.selectedWeeks.filter(week => week % 2 === 0).length;
+
+    if (this.selectedWeeks.length === this.allWeekList.length) {
+      // 如果没有选中任何周
+      this.weekType = 'all';
+    } else if (oddWeeksSelected === this.selectedWeeks.length) {
+      // 如果所有选中的周次都是单周
+      this.weekType = 'odd';
+    } else if (evenWeeksSelected === this.selectedWeeks.length) {
+      // 如果所有选中的周次都是双周
+      this.weekType = 'even';
+    } else {
+      // 如果选中的周数包含单周和双周
+      this.weekType = 'any';  // 不选中任何周类型
+    }
+  }
+  // 向父组件传递已选周数
+  emitWeekSelection() {
+    this.weekSelectionChange.emit({
+      weeks: this.selectedWeeks,
+      weekType: this.weekType
+    });
+    this.formControl.setValue(this.selectedWeeks);
+  }
+
+  writeValue(obj: any): void {
+  }
+  registerOnChange(fn: any): void {
+  }
+  registerOnTouched(fn: any): void {
+  }
+}

--- a/web/src/app/core/week-selector/week-selector.module.ts
+++ b/web/src/app/core/week-selector/week-selector.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {WeekSelectorComponent} from "./week-selector.component";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {NzButtonModule} from "ng-zorro-antd/button";
+import {NzCheckboxModule} from "ng-zorro-antd/checkbox";
+import {NzRadioModule} from "ng-zorro-antd/radio";
+import {NzFormModule} from "ng-zorro-antd/form";
+
+
+
+@NgModule({
+  declarations: [WeekSelectorComponent],
+  exports: [
+    WeekSelectorComponent
+  ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    NzButtonModule,
+    NzCheckboxModule,
+    NzRadioModule,
+    NzFormModule,
+    FormsModule
+  ]
+})
+export class WeekSelectorModule { }

--- a/web/src/app/dashboard/admin-dashboard/admin-dashboard.component.ts
+++ b/web/src/app/dashboard/admin-dashboard/admin-dashboard.component.ts
@@ -68,11 +68,11 @@ export class AdminDashboardComponent implements OnInit{
   }
 
   getAllCourseInfo() {
-    this.courseService.getAllCourseInfo(this.schoolIdAndWeeksData).subscribe(response => {
-      if (response.status){
-        this.schedule = this.convertToWeeklySchedule(response.data);
-      }
-    });
+    // this.courseService.getAllCourseInfo(this.schoolIdAndWeeksData).subscribe(response => {
+    //   if (response.status){
+    //     this.schedule = this.convertToWeeklySchedule(response.data);
+    //   }
+    // });
   }
 
   // 将从后端获得的数据转换为 WeeklySchedule 类型

--- a/web/src/app/me/me.component.html
+++ b/web/src/app/me/me.component.html
@@ -59,8 +59,8 @@
                 </button>
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
               </div>
-        </div>
-      </div>
+            </div>
+          </div>
         </div>
       </span>
     </div>

--- a/web/src/app/my-schedule/my-schedule.component.html
+++ b/web/src/app/my-schedule/my-schedule.component.html
@@ -34,7 +34,8 @@
           </ng-container>
           <ng-template #noCourse>
             <button *ngIf="canAddCourse(day, period.time)"
-                    (click)="openAddCourseModal(day, period.time, addCourseModal)"
+                    (click)="openAddCourseModal(day, period.time)"
+                    data-toggle="modal" data-target="#addCourseModal"
                     class="btn btn-sm d-flex align-items-center justify-content-center add-course-button">
               <span>➕</span>
             </button>
@@ -46,27 +47,69 @@
   </table>
 </div>
 
-<!-- 模态框：用于新增课程 -->
-<ng-template #addCourseModal let-modal>
-  <div class="modal-header">
-    <h4 class="modal-title">新增课程</h4>
-    <button type="button" class="close" (click)="modal.dismiss()">×</button>
+<div class="modal fade" id="addCourseModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">课程新增</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <form [formGroup]="formGroup">
+          <div class="mb-3 row">
+            <label for="term" class="col-sm-2 col-form-label">学期</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" name="term" id="term" [value]="termName" readonly />
+            </div>
+          </div>
+          <div class="form-group mb-3 row">
+            <label for="name" class="col-sm-2 col-form-label">课程名:</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" id="name" formControlName="name">
+              <div class="text-danger"
+                   *ngIf="formGroup.get('name')?.invalid">
+                课名不能为空
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="weeks" class="col-form-label" id="weeks">周次:</label>
+            <app-week-selector [allWeeks]="totalWeeks" (weekSelectionChange)="onWeekSelectionChange($event)" formControlName="weeks"></app-week-selector>
+            <div class="text-danger" *ngIf="formGroup.get('week')?.invalid">
+              周数不能为空
+            </div>
+          </div>
+          <div class="form-group mb-3 row">
+            <label for="day" class="col-sm-2 col-form-label">星期:</label>
+            <div class="col-sm-10">
+              <!-- 使用管道将数字转换为格式化字符串 -->
+              <input type="text" class="form-control" id="day" formControlName="day"
+                     [value]="(formGroup.get('day')?.value || 0) | weekFormat" readonly />
+            </div>
+          </div>
+          <div class="form-group mb-3 row">
+            <label for="begin" class="col-sm-2 col-form-label">开始节数:</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" id="begin" formControlName="begin"
+              [value]="(formGroup.get('begin')?.value || 0) | dayFormat" readonly />
+            </div>
+          </div>
+          <div class="form-group mb-3 row">
+            <label for="length" class="col-sm-2 col-form-label">持续节数:</label>
+            <div class="col-sm-10">
+              <select class="custom-select my-1 mr-sm-2" id="length" formControlName="length">
+                <option *ngFor="let length of availableLengths" [value]=length>{{ length }}</option>
+              </select>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
+        <button type="button" class="btn btn-primary" (click)="onSubmit()">添加</button>
+      </div>
+    </div>
   </div>
-  <div class="modal-body">
-    <form (ngSubmit)="submitCourseForm()">
-      <div class="form-group">
-        <label for="courseName">课程名</label>
-        <input type="text" id="courseName" [(ngModel)]="courseName" name="courseName" class="form-control" required />
-      </div>
-      <div class="form-group">
-        <label for="weeks">周数</label>
-        <input type="text" id="weeks" [(ngModel)]="weeks" name="weeks" class="form-control" placeholder="如：1,2,3" required />
-      </div>
-      <div class="form-group">
-        <label for="length">持续节数</label>
-        <input type="number" id="length" [(ngModel)]="length" name="length" class="form-control" required />
-      </div>
-      <button type="submit" class="btn btn-primary">确认</button>
-    </form>
-  </div>
-</ng-template>
+</div>

--- a/web/src/app/my-schedule/my-schedule.component.spec.ts
+++ b/web/src/app/my-schedule/my-schedule.component.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MyScheduleComponent } from './my-schedule.component';
+import {WeekSelectorModule} from "../core/week-selector/week-selector.module";
+import {NzRadioModule} from "ng-zorro-antd/radio";
+import {ReactiveFormsModule} from "@angular/forms";
+import {DayFormatPipe, WeekFormatPipe} from "../pipe/course-pipes";
 
 describe('MyScheduleComponent', () => {
   let component: MyScheduleComponent;
@@ -8,7 +12,14 @@ describe('MyScheduleComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ MyScheduleComponent ]
+      declarations: [ MyScheduleComponent ],
+      imports: [
+        WeekSelectorModule,
+        NzRadioModule,
+        ReactiveFormsModule,
+        DayFormatPipe,
+        WeekFormatPipe
+      ]
     })
     .compileComponents();
 

--- a/web/src/app/my-schedule/my-schedule.module.ts
+++ b/web/src/app/my-schedule/my-schedule.module.ts
@@ -3,14 +3,25 @@ import { CommonModule } from '@angular/common';
 
 import { MyScheduleRoutingModule } from './my-schedule-routing.module';
 import {MyScheduleComponent} from "./my-schedule.component";
-import {FormsModule} from "@angular/forms";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {NzSelectModule} from "ng-zorro-antd/select";
+import {WeekSelectorModule} from "../core/week-selector/week-selector.module";
+import * as fromPipes from '../pipe/course-pipes';
 
 @NgModule({
-  declarations: [MyScheduleComponent],
-  imports: [
-    CommonModule,
-    MyScheduleRoutingModule,
-    FormsModule,
-  ]
+  declarations: [
+    MyScheduleComponent,
+
+  ],
+    imports: [
+        CommonModule,
+        MyScheduleRoutingModule,
+        FormsModule,
+        NzSelectModule,
+        ReactiveFormsModule,
+        WeekSelectorModule,
+        fromPipes.DayFormatPipe,
+        fromPipes.WeekFormatPipe
+    ]
 })
 export class MyScheduleModule { }

--- a/web/src/app/pipe/course-pipes.ts
+++ b/web/src/app/pipe/course-pipes.ts
@@ -1,0 +1,30 @@
+import { Pipe, PipeTransform} from "@angular/core";
+
+@Pipe({
+  standalone: true,
+  name: 'dayFormat'
+})
+export class DayFormatPipe implements PipeTransform {
+  // 转换小节数
+  transform(day: number): string {
+    if (day === 0) {
+      return '未知'
+    }
+    return `第${day}小节`;
+  }
+}
+
+@Pipe({
+  standalone: true,
+  name: 'weekFormat'
+})
+export class WeekFormatPipe implements PipeTransform {
+  // 转换星期数
+  transform(week: number): string {
+    if (week === 0) {
+      return '未知';
+    }
+    const daysOfWeek = ['一', '二', '三', '四', '五', '六', '日'];
+    return `星期${daysOfWeek[week - 1] || '未知'}`;
+  }
+}


### PR DESCRIPTION
模态框中的周数和开始小节数，是根据用户选择的单元格而生成的对应位置。而持续小节，则是根据带单元格的begin结合一天总的小节数（11）来计算得来的。
周类型：全选择默认选中全周；所选的周数，全部为单周，则选中单周；当有混合周数时，周类型为'any'，但是不在选择器上体现
![image](https://github.com/user-attachments/assets/5cf00b02-b703-4667-8701-cee095e9e88a)
